### PR TITLE
#22: homepage left pois ja middle ja right asettelua 

### DIFF
--- a/frontend/src/components/content/homepage/Comingsoon.css
+++ b/frontend/src/components/content/homepage/Comingsoon.css
@@ -1,22 +1,19 @@
-.event-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* Keskitä sisällön vaakasuunnassa */
-}
+
 .events-container {
   display: flex;
   justify-content: center;
   align-items: center;
   margin-top: 0vmin;
   margin-bottom: 1vmin;
-  margin-left: 2vmin;
-  margin-right: 2vmin;
+  /*margin-left: 2vmin;
+  margin-right: 2vmin;*/
   font-family: sans-serif;
   overflow: hidden;
-  transform: skew(5deg);
+  /*transform: skew(5deg);*/
 }
+
 .event-item {
-  flex: 1;
+  flex: 1.1;
   transition: all 1s ease-in-out;
   height: 40vmin;
   position: relative;

--- a/frontend/src/components/content/homepage/Favoriteitems.css
+++ b/frontend/src/components/content/homepage/Favoriteitems.css
@@ -1,6 +1,0 @@
-.event-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* Keskitä sisällön vaakasuunnassa */
-}
-

--- a/frontend/src/components/content/homepage/Home.css
+++ b/frontend/src/components/content/homepage/Home.css
@@ -1,46 +1,48 @@
 .home-container {
-  height: 2500px;
+  /*height: 2500px;*/
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .left-container,
 .right-container {
-  width: 15%;
+  width: 18%;
 }
 
 .mid-container {
+
   width: 80%;
-  display: flex;
-  flex-direction: column;
+  /*display: flex;
+  flex-direction: column;*/
 }
 
 .uppercontent {
-  height: 700px;
+  max-height: 700px;
   overflow: hidden;
   padding-top: 0%;
-  padding-left: 15%;
-  padding-right: 15%;
+  padding-left: 3%;
+  padding-right: 10%;
 }
 .uppermiddlecontent{
-  height: 700px;
+  max-height: 700px;
   overflow: hidden;
   padding-top: 0%;
-  padding-left: 15%;
-  padding-right: 15%;
+  padding-left: 3%;
+  padding-right: 10%;
 }
 .lowermiddlecontent{
-  height: 700px;
+  max-height: 700px;
   overflow: hidden;
   padding-top: 0%;
-  padding-left: 15%;
-  padding-right: 15%;
+  padding-left: 3%;
+  padding-right: 10%;
 }
 .lowercontent{
-  height: 700px;
+  max-height: 700px;
   overflow: hidden;
   padding-top: 0%;
-  padding-left: 15%;
-  padding-right: 15%;
+  padding-left: 3%;
+  padding-right: 10%;
 }
 

--- a/frontend/src/components/content/homepage/Home.css
+++ b/frontend/src/components/content/homepage/Home.css
@@ -11,38 +11,20 @@
 }
 
 .mid-container {
-
   width: 80%;
   /*display: flex;
   flex-direction: column;*/
 }
 
-.uppercontent {
+.uppercontent,
+.uppermiddlecontent,
+.lowermiddlecontent,
+.lowercontent {
   max-height: 700px;
   overflow: hidden;
   padding-top: 0%;
   padding-left: 3%;
-  padding-right: 10%;
+  padding-right: 3%;
 }
-.uppermiddlecontent{
-  max-height: 700px;
-  overflow: hidden;
-  padding-top: 0%;
-  padding-left: 3%;
-  padding-right: 10%;
-}
-.lowermiddlecontent{
-  max-height: 700px;
-  overflow: hidden;
-  padding-top: 0%;
-  padding-left: 3%;
-  padding-right: 10%;
-}
-.lowercontent{
-  max-height: 700px;
-  overflow: hidden;
-  padding-top: 0%;
-  padding-left: 3%;
-  padding-right: 10%;
-}
+
 

--- a/frontend/src/components/content/homepage/Home.jsx
+++ b/frontend/src/components/content/homepage/Home.jsx
@@ -10,13 +10,18 @@ const Home = () => {
 
   return (
 
+    <div className='content'>
+
     <div className='home-container'>
 
+      {/*
       <div className='left-container'>
         <Leftsidebar />
       </div>
+      */}
 
       <div className='mid-container'>
+
         <div className='uppercontent'>
           <div className="coming-soon-container">
             <h2>Tulossa Finnkinoon</h2>
@@ -33,10 +38,15 @@ const Home = () => {
         <div className='lowercontent'>
             <h2>Lempileffat</h2> 
         </div>
+
       </div>
+      
       <div className='right-container'>
+        <h2>Seuraavat näytökset lähelläsi</h2> 
           <Rightsidebar />
       </div>
+
+    </div>
     </div>
   );
 };

--- a/frontend/src/components/content/homepage/Home.jsx
+++ b/frontend/src/components/content/homepage/Home.jsx
@@ -14,12 +14,6 @@ const Home = () => {
 
     <div className='home-container'>
 
-      {/*
-      <div className='left-container'>
-        <Leftsidebar />
-      </div>
-      */}
-
       <div className='mid-container'>
 
         <div className='uppercontent'>
@@ -42,7 +36,6 @@ const Home = () => {
       </div>
       
       <div className='right-container'>
-        <h2>Seuraavat näytökset lähelläsi</h2> 
           <Rightsidebar />
       </div>
 

--- a/frontend/src/components/content/homepage/Latestreviews.css
+++ b/frontend/src/components/content/homepage/Latestreviews.css
@@ -1,6 +1,0 @@
-.event-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* Keskitä sisällön vaakasuunnassa */
-}
-

--- a/frontend/src/components/content/homepage/Leftsidebar.css
+++ b/frontend/src/components/content/homepage/Leftsidebar.css
@@ -1,6 +1,0 @@
-.event-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* Keskitä sisällön vaakasuunnassa */
-}
-

--- a/frontend/src/components/content/homepage/Popularmovies.css
+++ b/frontend/src/components/content/homepage/Popularmovies.css
@@ -10,12 +10,11 @@
   align-items: center;
   margin-top: 0vmin;
   margin-bottom: 1vmin;
-  margin-left: 2vmin;
-  margin-right: 2vmin;
+  /*margin-left: 2vmin;
+  margin-right: 2vmin;*/
   font-family: sans-serif;
   overflow: hidden;
   transform: skew(-5deg);
-
 }
 
 .fmovie-item {

--- a/frontend/src/components/content/homepage/Rightsidebar.css
+++ b/frontend/src/components/content/homepage/Rightsidebar.css
@@ -1,7 +1,17 @@
 .event-list {
+  background-color: #ffffff;
   justify-content: center; 
   align-items: center; 
 }
+
+.nearbyEvents {
+  margin: 0;
+}
+
+.nearby {
+  margin: 0;
+}
+
 .event-list ul {
   margin-left: 0;
   display: inline-flex;
@@ -12,32 +22,35 @@
   font-size: 1em;
 }
 
-.nearby td {
-  text-align: left;
-  display: block;
+.nearby tr {
+  width: 100%;
 }
 
-.nearby tr:hover td {
+.nearby td {
+  width: 300px;
+  text-align: left;
+  display: block;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.nearby tr:hover {
   background-color: rgba(0, 0, 0, 0.1); 
 }
 
-.nearby tr:hover td b {
-  font-weight: bold; 
-}
-
 .show-more-button {
+  margin-top: 9px;
   background-color: transparent;
   border: none; 
   padding: 10px 20px; 
   border-radius: 5px; 
-
   cursor: pointer; 
   transition: background-color 0.3s ease; 
   color: grey;
+  font-size: 1.1em;
 }
 
 .show-more-button:hover {
-
   background-color: rgba(0, 0, 0, 0.1); 
 }
 

--- a/frontend/src/components/content/homepage/Rightsidebar.css
+++ b/frontend/src/components/content/homepage/Rightsidebar.css
@@ -6,6 +6,8 @@
 
 .nearbyEvents {
   margin: 0;
+  padding-left: 10%;
+  width: 300px;
 }
 
 .nearby {

--- a/frontend/src/components/content/homepage/Rightsidebar.jsx
+++ b/frontend/src/components/content/homepage/Rightsidebar.jsx
@@ -161,7 +161,7 @@ const Rightsidebar = () => {
 
 
   return (
-    <div className="event-list">
+    <>
       {loading && <p>Ladataan...</p>}
       {error && <p>{error}</p>}
       {location && (
@@ -175,8 +175,8 @@ const Rightsidebar = () => {
                       <table className="nearby"  key={index}>
                         <tbody>
                           <tr onClick={() => handleClick(show.title, show.year)}>
-                            <td width="270px"><b>{show.auditorium}</b></td>
-                            <td width="120px"><b>{formatTime(show.startTime)}</b></td>
+                            <td><b>{show.auditorium}</b></td>
+                            <td>klo <b>{formatTime(show.startTime)}</b></td>
                             <td>{show.title}</td>
                           </tr>
                         </tbody>
@@ -184,17 +184,17 @@ const Rightsidebar = () => {
                     </div>
                     ))}
                   
-                <button onClick={showLess} className='show-more-button'>{'<'}</button>
+                <button onClick={showLess} className='show-more-button'>{'⯇'}</button>
 
                Selaa 
               
-                <button onClick={showMore} className='show-more-button'>{'>'}</button>
+                <button onClick={showMore} className='show-more-button'>{'⯈'}</button>
                 
             </div> 
           )}
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/components/content/homepage/Rightsidebar.jsx
+++ b/frontend/src/components/content/homepage/Rightsidebar.jsx
@@ -166,8 +166,10 @@ const Rightsidebar = () => {
       {error && <p>{error}</p>}
       {location && (
         <div>
+          
           {nearestTheater && (
             <div className="nearbyEvents" >
+              <h2>Seuraavat näytökset lähelläsi</h2> 
                 
                 {shows.slice(showCount - 10, showCount).map((show, index) => (
     
@@ -186,7 +188,7 @@ const Rightsidebar = () => {
                   
                 <button onClick={showLess} className='show-more-button'>{'⯇'}</button>
 
-               Selaa 
+                &nbsp; Selaa &nbsp; 
               
                 <button onClick={showMore} className='show-more-button'>{'⯈'}</button>
                 

--- a/frontend/src/css/media.css
+++ b/frontend/src/css/media.css
@@ -3,21 +3,66 @@
     width: 80%;
   }
 
+  .uppercontent,
+  .uppermiddlecontent,
+  .lowermiddlecontent,
+  .lowercontent {
+    margin-left: -10%;
+  }
+
 }
 
 @media (max-width: 1470px) {
-.menu-items li{
-  list-style-type: none;
-  padding-left: 25px;
-}
+  .menu-items li{
+    list-style-type: none;
+    padding-left: 25px;
+  }
 
-
-
-.posterimg {
-    max-height: 500px;
-}
+  .posterimg {
+      max-height: 500px;
+  }
 
 }
+
+
+@media (max-width: 1250px) {
+  .home-container {
+    display: block;
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+
+  .mid-container {
+    display: contents;
+    width: 100%;
+    /*display: flex;
+    flex-direction: column;*/
+  }
+
+  .uppercontent,
+  .uppermiddlecontent,
+  .lowermiddlecontent,
+  .lowercontent {
+    margin: 0 auto;
+    width: 100%;
+    
+  }
+
+  .right-container {
+    display: block;
+  }
+
+  .nearbyEvents {
+    padding-top: 40px;
+    padding-bottom: 10px;
+  }
+
+  .nearby {
+    padding-left: 20px;
+  }
+  
+}
+
 
 @media (max-width: 1040px) {
   .menu-items-left {
@@ -33,117 +78,118 @@
   padding-left: 25px;
 }
 
-#header-bar ul.username {
-  color: #ffffff;
-  margin-top: 7px;
-  margin-right: 73px;
-  font-size: 0.9em;
-}
+  #header-bar ul.username {
+    color: #ffffff;
+    margin-top: 7px;
+    margin-right: 73px;
+    font-size: 0.9em;
+  }
 
-.content {
-  width: 90%;
+  .content {
+    width: 90%;
 
-}
+  }
 
-.login-menu {
-  right: 100px;
-}
+  .login-menu {
+    right: 100px;
+  }
 
-.posterimg {
-  max-height: 450px;
-}
-
+  .posterimg {
+    max-height: 450px;
+  }
 
 }
 
 
 @media (max-width: 640px) {
+  #header-bar .header-container {
+    margin-left: 35px;
+  }
 
-#header-bar .header-container {
-  margin-left: 35px;
-}
+  #header-bar ul.whiteLinks {
+    display: none; 
+  }
 
-#header-bar ul.whiteLinks {
-  display: none; 
-}
+  .menu-items-right {
+    display: none; 
+  }
 
-.menu-items-right {
-  display: none; 
-}
+  ul .whitelinks {
+    display: none; 
+  }
 
-ul .whitelinks {
-  display: none; 
-}
+  #header-bar ul.username {
+    display: none; 
+  }
 
-#header-bar ul.username {
-  display: none; 
-}
+  .menu-items-left {
+    display: none; 
+  }
 
-.menu-items-left {
-  display: none; 
-}
+  #header-bar ul {
+    font-size: 1.2em;
+    margin-top: 45px;
+  }
 
-#header-bar ul {
-  font-size: 1.2em;
-  margin-top: 45px;
-}
+  .moviemain {
+    display: flex;
+    flex-wrap: wrap;
+  }
 
-.moviemain {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.posterimg {
-  max-height: 350px;
-}
+  .posterimg {
+    max-height: 350px;
+  }
 
 }
 
 
 @media (max-width: 570px) {
+  .moviemain {
+    display: flex;
+    flex-wrap: wrap;
+  }
 
-.moviemain {
-  display: flex;
-  flex-wrap: wrap;
-}
+  #header-bar {
+    width: 100%;
+  }
 
-#header-bar {
-  width: 100%;
-}
+  #header-bar .header-container {
+    margin-left: 30px;
+  }
 
-#header-bar .header-container {
-  margin-left: 30px;
-}
+  #header-bar ul.whiteLinks {
+    display: none; 
+  }
 
-#header-bar ul.whiteLinks {
-  display: none; 
-}
+  .menu-items-right {
+    display: none; 
+  }
 
-.menu-items-right {
-  display: none; 
-}
+  ul .whitelinks {
+    display: none; 
+  }
 
-ul .whitelinks {
-  display: none; 
-}
+  #header-bar ul.username {
+    display: none; 
+  }
 
-#header-bar ul.username {
-  display: none; 
-}
+  .menu-items-left {
+    display: none; 
+  }
 
-.menu-items-left {
-  display: none; 
-}
+  .reviewslisted {
+    display: contents;
+  }
 
-.reviewslisted {
-  display: contents;
-}
+  .mobile-menu-icon {
+    margin-top: -8px;
+    margin-left: 10px;
+    font-size: 1.5em;
+  }
 
-.mobile-menu-icon {
-  margin-top: -8px;
-  margin-left: 10px;
-  font-size: 1.5em;
-}
+  .nearby {
+    padding-left: 10px;
+  }
 
 }
 
@@ -151,30 +197,30 @@ ul .whitelinks {
 @media (max-width: 340px) {
 
 .body > *:not(#screenError):not(h1):not(h2):not(h3) {
-  display: none;
-}
+    display: none;
+  }
 
-#footer {
-  display: none;
-}
+  #footer {
+    display: none;
+  }
 
-.body {
-  background-color: #ffffff;
-}
+  .body {
+    background-color: #ffffff;
+  }
 
-#screenError {
-  display: block;
-}
+  #screenError {
+    display: block;
+  }
 
-h1 {
-  font-family: "Grandstander", cursive;
-  font-weight: 400;
-  font-size: 3.2em;
-  color: #123d80;
-}
+  h1 {
+    font-family: "Grandstander", cursive;
+    font-weight: 400;
+    font-size: 3.2em;
+    color: #123d80;
+  }
 
-h2, h3 {
-  color: #000000;
-}
+  h2, h3 {
+    color: #000000;
+  }
 
 }


### PR DESCRIPTION

#22: homepage left pois ja middle ja right asettelua


## etusivulta
- lähdetty kokeilemaan sitä, että otettu left-container pois ja jäsennelty middle + right -containerit siten, että asettuvat päänäkymään näin: 

tietokone:
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/ae74cbec-3d55-4248-a947-be5b1626ddf1)

noin 1400px:
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/b6b736ef-b919-42d4-8a1a-1dc6f998add8)


alle 1250px muuntuu:
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/020edf58-cbc6-4761-8e5d-b76f55038286)
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/00c7d000-58e7-414c-9479-d4e81e88b200)

alle 900:
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/b4d2da15-6cf5-4439-87f3-ad481b833bde)

alle 500:
![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/ee3ba846-a642-4814-b13d-7e969e231bb6)












