### PR TITLE
#185: tietokantamuutos ja anonyymille profiilittomat arvostelut

### DIFF
--- a/backend/review/reviewModel.js
+++ b/backend/review/reviewModel.js
@@ -110,10 +110,21 @@ async function getReviewsByItem(id, mediatype) {
 async function updateReviewToAnon(profileid) {
   try {
     const query = {
-      text: 'UPDATE Review_ SET profileid = 1 WHERE profileid = $1',
+      text: 'UPDATE Review_ SET profileid = NULL WHERE profileid = $1',
       values: [profileid],
     };
     await queryDatabase(query);
+  } catch (error) {
+    throw error;
+  }
+}
+
+async function getAnonReviews () {
+  try {
+    const query = {
+      text: 'SELECT * FROM Review_ WHERE profileid IS NULL',
+    };
+    return await queryDatabase(query);
   } catch (error) {
     throw error;
   }
@@ -130,5 +141,6 @@ module.exports = {
   getReviewsByProfile,
   serieReviewExists,
   getReviewsByItem,
-  updateReviewToAnon
+  updateReviewToAnon, 
+  getAnonReviews,
 };

--- a/backend/review/reviewRoutes.js
+++ b/backend/review/reviewRoutes.js
@@ -15,6 +15,7 @@ router.get('/reviews/:id/:mediatype', reviewService.getReviewsByItem);
 router.get('/review/new', reviewService.getNewestReviews);
 router.put('/reviews/update/:id', reviewService.updateReview);
 router.put('/reviews/toanon', auth, reviewService.updateReviewToAnon);
+router.get('/reviews/anon', reviewService.getAnonReviews);
 router.delete('/review/:id', reviewService.deleteReview);
 
 module.exports = router;

--- a/backend/review/reviewService.js
+++ b/backend/review/reviewService.js
@@ -122,6 +122,16 @@ async function updateReviewToAnon(req, res) {
   }
 }
 
+async function getAnonReviews(req, res) {
+    const profileid = req.params.profileid;
+    try {
+    const reviews = await reviewModel.getAnonReviews(profileid);
+    res.json(reviews);
+  } catch (error) {
+    console.error('Virhe haettaessa arvosteluja:', error);
+    res.status(500).send('Virhe haettaessa arvosteluja');
+  }
+}
 
 module.exports = {
   getAllReviews,
@@ -133,5 +143,6 @@ module.exports = {
   serieReviewFromUser,
   getReviewsByItem,
   serieReviewExists,
-  updateReviewToAnon
+  updateReviewToAnon,
+  getAnonReviews,
 };

--- a/frontend/src/components/content/community/AllReviews.jsx
+++ b/frontend/src/components/content/community/AllReviews.jsx
@@ -18,15 +18,26 @@ const AllReviews = ({ searchTerm, setSearchTerm }) => {
 
   const fetchReviews = async () => {
     try {
-      const response = await axios.get(`${VITE_APP_BACKEND_URL}/reviews`);
-      const reviewData = response.data;
+      const newReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/reviews`);
+      //const anonReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/reviews/anon`);
       
+      const newReviews = newReviewResponse.data;
+      //const anonReviews = anonReviewResponse.data;
+      
+      //const reviewData = [...newReviews, ...anonReviews];
+
+      const reviewData = newReviews;
+
       // Haetaan profiilitiedot
       const reviewsWithProfiles = await Promise.all(reviewData.map(async review => {
         try {
-          const userProfileResponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/id/${review.profileid}`);
-          const userProfileData = userProfileResponse.data;
-          return { ...review, userProfile: userProfileData };
+          if (review.profileid !== null) {
+            const userProfileResponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/id/${review.profileid}`);
+            const userProfileData = userProfileResponse.data;
+            return { ...review, userProfile: userProfileData };
+          } else {
+            return review;
+          }
         } catch (error) {
           console.error('Error fetching profile:', error);
           return review;
@@ -143,7 +154,16 @@ const AllReviews = ({ searchTerm, setSearchTerm }) => {
                 <br/>
                 <span>{renderRatingIcons(review.rating)}</span>
                 <span className='userinfo'>| <b>{review.rating}/5</b> tähteä</span> <br />
-                <span className='reviewinfo'><span className='reviewinfo'>{formatDate(review.timestamp)}</span> | <Link className="reviewitems" to={`/profile/${review.userProfile.profilename}`}>{review.userProfile.profilename}</Link></span> <br />
+                <span className='reviewinfo'>
+                  <span className='reviewinfo'>{formatDate(review.timestamp)}</span> | &nbsp;
+                  {review.userProfile && review.userProfile.profilename !== undefined ? (
+                    <Link className="reviewitems" to={`/profile/${review.userProfile.profilename}`}>
+                      {review.userProfile.profilename}
+                    </Link>
+                  ) : (
+                    <i>anonyymi</i>
+                  )}
+                </span><br />
                 <span className='userinfo'>{review.review}</span> <br />
               </li>
             ))}

--- a/frontend/src/components/content/homepage/Latestreviews.jsx
+++ b/frontend/src/components/content/homepage/Latestreviews.jsx
@@ -13,11 +13,16 @@ const Latestreviews = () => {
   useEffect(() => {
     const fetchReviews = async () => {
       try {
-        const response = await axios.get(`${VITE_APP_BACKEND_URL}/review/new`);
-        const reviewData = response.data;
+        const newReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/review/new`);
+        const anonReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/reviews/anon`);
+        
+        const newReviews = newReviewResponse.data;
+        const anonReviews = anonReviewResponse.data;
+        
+        const allReviews = [...newReviews, ...anonReviews];
 
         // Hae jokaisen arvostelun review.revieweditem arvolla liittyvä elokuva
-        const reviewsWithMovies = await Promise.all(reviewData.map(async review => {
+        const reviewsWithMovies = await Promise.all(allReviews.map(async review => {
           try {
             let responseData;
             if (review.mediatype === 0) {
@@ -103,7 +108,7 @@ const Latestreviews = () => {
                       hour: 'numeric',
                       minute: 'numeric',
                     })}</p>
-                    <p><b>Arvostelija: </b> {review.profilename}</p>
+                    <p><b>Arvostelija: </b> {review.profilename || <i>anonyymi</i>}</p>
                   </td>
                 </tr>
               </tbody>

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -74,13 +74,25 @@ CREATE TABLE IF NOT EXISTS Favoritelist_
 -- Arvostelut
 CREATE TABLE IF NOT EXISTS Review_ (
     idreview SERIAL PRIMARY KEY,
-    profileid INTEGER NOT NULL,
+    profileid INTEGER,
     revieweditem VARCHAR(40),
     review VARCHAR(2000),
     rating SMALLINT NOT NULL,
     timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     mediatype SMALLINT,
     FOREIGN KEY (profileid) REFERENCES Profile_(profileid) ON DELETE CASCADE,
-    CONSTRAINT unique_review UNIQUE (profileid, revieweditem),
+    CONSTRAINT unique_review UNIQUE NULLS DISTINCT (profileid, revieweditem, mediatype),
     CONSTRAINT check_rating_range CHECK (rating >= 1 AND rating <= 5)
 );
+
+ALTER SEQUENCE public.profile__profileid_seq RESTART WITH 1;
+ALTER SEQUENCE public.group__groupid_seq RESTART WITH 1;
+ALTER SEQUENCE public.review__idreview_seq RESTART WITH 1;
+ALTER SEQUENCE public.favoritelist__idfavoritelist_seq RESTART WITH 1;
+ALTER SEQUENCE public.memberlist__memberlistid_seq RESTART WITH 1;
+ALTER SEQUENCE public.message__messageid_seq RESTART WITH 1;
+
+--ALTER TABLE Review_ 
+--DROP CONSTRAINT unique_review,
+--ADD CONSTRAINT unique_review UNIQUE NULLS DISTINCT (profileid, revieweditem, mediatype);
+


### PR DESCRIPTION
- Eli nyt käyttäjän poistuessa palvelusta hän voi jättää arvostelunsa anonyymeiksi niin halutessaan
- Tällaiset arvostelut välittyvät profileid:n sarakkeeseen NULL-arvoilla, jolloin niitä ei myöskään koske rajoitukset (eli anonyymeja arvosteluita voi olla samosisa leffoissa ja sarjoissa)
- Tietokantamuutos tähän liittyen sekä sequence restartit, jotta aletaan ID-laskut alusta, mikäli kanta ajetaan uusiksi sisään kokonaan


![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/96a153f2-238b-4947-9d60-4e44ef71d471)

![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/59574306-2fc8-4f84-8577-adb2d676c6f5)

![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/ee3c1cf7-16d9-4aa2-8945-feda87f74b86)

![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/58afc11c-be30-4740-8468-bb299c509449)
