### PR TITLE
#139: Admin-toiminnallisuutta

### DIFF
--- a/backend/group/groupModel.js
+++ b/backend/group/groupModel.js
@@ -71,7 +71,7 @@ async function deleteGroupById(groupid) {
 async function updateGroupById(groupid, grouppicurl, groupexplanation) {
     const now = new Date();
     const query = {
-        text: 'UPDATE group_ SET grouppicurl = $2, groupexplanation = $3, timestamp = $4 WHERE groupid = $1',
+        text: 'UPDATE group_ SET grouppicurl = $2, groupexplanation = $3, last_modified = $4 WHERE groupid = $1',
         values: [groupid, grouppicurl, groupexplanation, now],
     };
     return queryDatabase(query);

--- a/backend/group/groupRoutes.js
+++ b/backend/group/groupRoutes.js
@@ -18,7 +18,7 @@ router.get('/messages/:groupid', groupService.getMessagesById);
 router.post('/messages', auth, groupService.createMessage);
 router.delete('/messages/:messageid', auth, groupService.deleteMessage);
 router.get('/memberstatus/:profileid/:groupid', groupService.getMemberStatus);
-router.post('/memberstatus/:profileid/:mainuser/:groupid/:pending', auth, groupService.createMember);
+router.post('/memberstatus/:profileid/:mainuser/:groupid/:pending', groupService.createMember);
 router.put('/memberstatus/:memberlistid/:pending', auth, groupService.updateMemberStatus);
 router.put('/memberrank/:memberlistid/:mainuser', auth, groupService.updateMemberRank);
 router.delete('/memberstatus/:memberlistid', auth, groupService.deleteMember);

--- a/backend/group/groupRoutes.js
+++ b/backend/group/groupRoutes.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const groupService = require('./groupService')
-const { auth, optionalAuth } = require('../middleware/auth');
+const { auth } = require('../middleware/auth');
 
-router.use(express.json());
+//router.use(express.json());
 
 // kaikki nämä ovat käytössä
 router.get('/group', groupService.getAllGroups);
@@ -18,14 +18,13 @@ router.get('/messages/:groupid', groupService.getMessagesById);
 router.post('/messages', auth, groupService.createMessage);
 router.delete('/messages/:messageid', auth, groupService.deleteMessage);
 router.get('/memberstatus/:profileid/:groupid', groupService.getMemberStatus);
-router.post('/memberstatus/:profileid/:mainuser/:groupid/:pending', groupService.createMember);
+router.post('/memberstatus/:profileid/:mainuser/:groupid/:pending', auth, groupService.createMember);
 router.put('/memberstatus/:memberlistid/:pending', auth, groupService.updateMemberStatus);
 router.put('/memberrank/:memberlistid/:mainuser', auth, groupService.updateMemberRank);
 router.delete('/memberstatus/:memberlistid', auth, groupService.deleteMember);
 router.delete('/memberlist/:groupid', auth, groupService.deleteMemberlist);
 router.get('/groups/getnewest', groupService.getNewestGroup);
 router.get('/groups/getpopular', groupService.getPopularGroup);
-// ovatko nämä käytössä jossain? en löytänyt näitä!
 router.get('/group/groupname/:groupid', groupService.getGroupNameById);
 router.post('/memberlist', auth, groupService.createMemberList);
 router.get('/grouplist/:profileid', groupService.getUserGroups);

--- a/backend/profile/profileModel.js
+++ b/backend/profile/profileModel.js
@@ -49,14 +49,13 @@ async function deleteProfileById(profileid) {
         await pool.query('COMMIT');
         console.log('deleteProfileById result', result);
         return result.rowCount;
-        
     }
     catch (error) {
         await pool.query('ROLLBACK');
         throw error; 
     }
 } 
-
+  
 async function updateProfilenameAndEmail(profileid, profilename, email) {
     const now = new Date();
     const query = {

--- a/backend/profile/profileRoutes.js
+++ b/backend/profile/profileRoutes.js
@@ -10,6 +10,7 @@ router.get('/profile', profileService.getAllProfiles);
 router.get('/profile/id/:profileid', profileService.getProfileById);
 router.get('/profile/:profilename', optionalAuth, profileService.getProfileByName);
 router.delete('/profile', auth, profileService.deleteProfileById);
+router.delete('/admin/deleteprofile/:id', auth, profileService.deleteProfileAsAdmin);
 router.put('/profile/nameandemail', auth, profileService.updateProfilenameAndEmail);
 router.put('/profile', auth, profileService.updateProfileDetails);
 router.put('/profile/visibility', auth, profileService.updateProfileVisibility);

--- a/backend/profile/profileRoutes.js
+++ b/backend/profile/profileRoutes.js
@@ -2,7 +2,6 @@ const express = require('express');
 const router = express.Router();
 const profileService = require('./profileService');
 const { auth, optionalAuth } = require('../middleware/auth');
-const pool = require('../database/db_connection');
 
 
 // kaikki nämä ovat käytössä

--- a/backend/profile/profileService.js
+++ b/backend/profile/profileService.js
@@ -42,6 +42,17 @@ async function deleteProfileById(req, res) {
     }
 }
 
+async function deleteProfileAsAdmin(req, res) {
+    const profileid = req.params.groupid;
+    try {
+        await profileModel.deleteProfileById(profileid);
+        res.status(200).json({ message: `Tietue poistettu onnistuneesti` });
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    }
+}
+
+
 async function updateProfilenameAndEmail(req, res) {
     const profileid = res.locals.profileid;
     const { profilename, email } = req.body;
@@ -82,5 +93,6 @@ module.exports = {
     deleteProfileById,
     updateProfilenameAndEmail,
     updateProfileDetails,
-    updateProfileVisibility
+    updateProfileVisibility,
+    deleteProfileAsAdmin,
 };

--- a/backend/profile/profileService.js
+++ b/backend/profile/profileService.js
@@ -43,7 +43,7 @@ async function deleteProfileById(req, res) {
 }
 
 async function deleteProfileAsAdmin(req, res) {
-    const profileid = req.params.groupid;
+    const profileid = req.params.id;
     try {
         await profileModel.deleteProfileById(profileid);
         res.status(200).json({ message: `Tietue poistettu onnistuneesti` });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import AllReviews from '@content/community/AllReviews';
 import Error from '@content/error/Error';
 import ProfileEdit from '@content/user/ProfileEdit';
 import ReviewForm from '@content/movies/ReviewForm';
+import AdminPage from '@content/admin/AdminPage';
 import Faq from '@content/faq/Faq';
 import { jwtToken, usertype } from './components/auth/authSignal';
 const { VITE_APP_BACKEND_URL } = import.meta.env;
@@ -122,7 +123,7 @@ function App() {
               <Route path="/reviews" element={<AllReviews usertype={usertype} />} />
               <Route path="/about" element={<Faq />} />
               <Route path="/group/:id" element={<GroupDetails user={user} />} />
-              {/* ja loput puuttuvat routet myös */}
+              <Route path="/admin" element={<AdminPage user={user} usertype={usertype} />} />
             </Routes>
 
           </div>

--- a/frontend/src/components/content/admin/AdminDeleteGroups.jsx
+++ b/frontend/src/components/content/admin/AdminDeleteGroups.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { getHeaders } from '@auth/token';
+
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
+const AdminDeleteGroups = ({ id, handleDelete }) => {
+
+  const headers = getHeaders();
+  const [confirmDeleteGroupId, setConfirmDeleteGroupId] = useState(null);
+
+
+  const handleDeleteGroup = async () => {
+    try {
+        const response = await axios.delete(`${VITE_APP_BACKEND_URL}/group/${id}`, { headers });
+        console.log(response.data);
+        handleDelete(id);
+        setConfirmDeleteGroupId(null);
+    } catch (error) {
+        console.error('Virhe poistaessa ryhmää:', error);
+    }
+};
+
+  return (
+    <div>
+      <>
+        {confirmDeleteGroupId === id.idgroup ? (
+          <>
+            <button className="confirm" onClick={() => handleDeleteGroup(id.idgroup)}><span className='group uni12'></span> Vahvista</button>
+            <button className="compactButton" onClick={() => setConfirmDeleteGroupId(null)}>Peruuta</button>
+          </>
+        ) : (
+          <button className="compactButton" onClick={() => setConfirmDeleteGroupId(id.idgroup)}><span className='group uni12'></span> Poista ryhmä</button>
+        )}
+      </>
+
+    </div>
+  );
+};
+
+export default AdminDeleteGroups;

--- a/frontend/src/components/content/admin/AdminDeleteReview.jsx
+++ b/frontend/src/components/content/admin/AdminDeleteReview.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { getHeaders } from '@auth/token';
+
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
+const AdminDeleteReview = ({ id, handleDelete }) => {
+
+  const headers = getHeaders();
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+
+  const handleDeleteReview = async () => {
+    try {
+        const response = await axios.delete(`${VITE_APP_BACKEND_URL}/admin/deletereview/${id}`, { headers });
+        console.log(response.data);
+        handleDelete(id);
+        setConfirmDeleteId(null);
+    } catch (error) {
+        console.error('Virhe poistaessa arvostelua:', error);
+    }
+  };
+
+  return (
+    <div>
+        <>
+        {confirmDeleteId === id.idreview ? (
+          <>
+            <button className="confirm" onClick={() => handleDeleteReview(id.idreview)}><span className='review uni12'></span> Vahvista</button>
+            <button className="compactButton" onClick={() => setConfirmDeleteId(null)}>Peruuta</button>
+          </>
+        ) : (
+          <button className="compactButton" onClick={() => setConfirmDeleteId(id.idreview)}><span className='review uni12'></span> Poista arvostelu</button>
+        )}
+      </>
+
+    </div>
+  );
+};
+
+export default AdminDeleteReview;

--- a/frontend/src/components/content/admin/AdminDeleteUsers.jsx
+++ b/frontend/src/components/content/admin/AdminDeleteUsers.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { getHeaders } from '@auth/token';
+
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
+const AdminDeleteUsers = ({ id, handleDelete }) => {
+
+  const headers = getHeaders();
+  const [confirmDeleteAccountId, setConfirmDeleteAccountId] = useState(null);
+
+
+  const handleDeleteAccount = async () => {
+      try {
+          const response = await axios.delete(`${VITE_APP_BACKEND_URL}/admin/deleteprofile/${id}`, { headers });
+          console.log(response.data);
+          handleDelete(id);
+          setConfirmDeleteAccountId(null);
+      } catch (error) {
+          console.error('Virhe poistaessa käyttäjää:', error);
+      }
+  };
+
+  return (
+    <div>
+
+      <>
+        {confirmDeleteAccountId === id.idprofile ? (
+          <>
+            <button className="confirm" onClick={() => handleDeleteAccount(id.idprofile)}><span className='user uni12'></span> Vahvista</button>
+            <button className="compactButton" onClick={() => setConfirmDeleteAccountId(null)}>Peruuta</button>
+          </>
+        ) : (
+          <button className="compactButton" onClick={() => setConfirmDeleteAccountId(id.idprofile)}><span className='user uni12'></span> Poista käyttäjä</button>
+        )}
+      </>
+
+    </div>
+  );
+};
+
+export default AdminDeleteUsers;

--- a/frontend/src/components/content/admin/AdminDeleteUsers.jsx
+++ b/frontend/src/components/content/admin/AdminDeleteUsers.jsx
@@ -20,18 +20,19 @@ const AdminDeleteUsers = ({ id, handleDelete }) => {
           console.error('Virhe poistaessa käyttäjää:', error);
       }
   };
+  
 
   return (
     <div>
 
       <>
-        {confirmDeleteAccountId === id.idprofile ? (
+        {confirmDeleteAccountId === id.profileid ? (
           <>
-            <button className="confirm" onClick={() => handleDeleteAccount(id.idprofile)}><span className='user uni12'></span> Vahvista</button>
+            <button className="confirm" onClick={() => handleDeleteAccount(id.profileid)}><span className='user uni12'></span> Vahvista</button>
             <button className="compactButton" onClick={() => setConfirmDeleteAccountId(null)}>Peruuta</button>
           </>
         ) : (
-          <button className="compactButton" onClick={() => setConfirmDeleteAccountId(id.idprofile)}><span className='user uni12'></span> Poista käyttäjä</button>
+          <button className="compactButton" onClick={() => setConfirmDeleteAccountId(id.profileid)}><span className='user uni12'></span> Poista käyttäjä</button>
         )}
       </>
 

--- a/frontend/src/components/content/admin/AdminPage.jsx
+++ b/frontend/src/components/content/admin/AdminPage.jsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect, user } from 'react';
+import './admins.css';
+import UsersAsList from './UsersAsList';
+import GroupsAsList from './GroupsAsList';
+import ReviewsAsList from './ReviewsAsList';
+import { getHeaders } from '@auth/token';
+
+const AdminPage = ({ user }) => {
+    const [userSearchTerm, setUserSearchTerm] = useState('');
+    const [groupSearchTerm, setGroupSearchTerm] = useState('');
+    const [reviewSearchTerm, setReviewSearchTerm] = useState('');
+
+    const headers = getHeaders();
+
+    console.log(user);
+  
+return (
+    <div className="content">
+      {user && user.usertype === 'admin' ? (
+          <>
+              <h2>Adminin paneeli</h2>
+              <UsersAsList searchTerm={userSearchTerm} setSearchTerm={setUserSearchTerm} user={user} />
+              <GroupsAsList searchTerm={groupSearchTerm} setSearchTerm={setGroupSearchTerm} user={user} />
+              <ReviewsAsList searchTerm={reviewSearchTerm} setSearchTerm={setReviewSearchTerm} user={user} />
+          </>
+      ) : (
+          <h2>Ei käyttöoikeutta sivulle.</h2>
+      )}
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/frontend/src/components/content/admin/GroupsAsList.jsx
+++ b/frontend/src/components/content/admin/GroupsAsList.jsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import AdminDeleteGroups from './AdminDeleteGroups';
+import './admins.css';
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
+const GroupsAsList = ({ user, searchTerm, setSearchTerm }) => {
+    const [groups, setGroups] = useState([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [groupsPerPage, setGroupsPerPage] = useState(10);
+    const [loading, setLoading] = useState(true);
+    const [profileId, setProfileid] = useState(null);
+    const [newGroupName, setNewGroupName] = useState('');
+    const [creatingGroup, setCreatingGroup] = useState(false);
+
+    useEffect(() => {
+        const fetchGroups = async () => {
+            try {
+                const response = await axios.get(`${VITE_APP_BACKEND_URL}/group`);
+                const sortedGroups = response.data.sort((a, b) => a.groupname.localeCompare(b.groupname));
+                setGroups(sortedGroups);
+                setLoading(false);
+            } catch (error) {
+                console.error('Error fetching groups:', error);
+                setLoading(false);
+            }
+        };
+
+        fetchGroups();
+    }, []);
+
+    const filteredGroups = groups.filter(group =>
+        group.groupname.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const indexOfLastGroup = currentPage * groupsPerPage;
+    const indexOfFirstGroup = indexOfLastGroup - groupsPerPage;
+    const currentGroups = filteredGroups.slice(indexOfFirstGroup, indexOfLastGroup);
+
+    const handleCreateGroup = async () => {
+        try {
+            const response = await axios.post(`${VITE_APP_BACKEND_URL}/group`, { groupname: newGroupName });  
+            console.log('palauttaako mitään', response.data);
+            const groupid = response.data[0].groupid;
+            await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/1/${groupid}/0`);
+            setNewGroupName('');
+            setCreatingGroup(false);
+            console.log('Uusi ryhmä luotu ja jäsen lisätty onnistuneesti');
+            window.location.href = `/group/${groupid}`;
+
+        } catch (error) {
+            console.error('Virhe luodessa ryhmää ja jäsentä:', error);
+        }
+    };
+
+    const handleDelete = async (id) => {
+       setGroups(groups.filter(group => group.groupid !== id));
+    };
+
+    return (
+        <div className="admin-view">
+            <div className="admin-left">
+                <h2>Ryhmien hallinnointi</h2>
+                {loading ? (
+                    <div className="loading-text">Ladataan Ryhmiä...</div>
+                ) : (
+                    <>
+                        {groups.length > groupsPerPage && (
+                            <ul className="pagination">
+                                <li>
+                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>⯇</button>
+                                    &nbsp; <span className="communityBox">selaa</span> &nbsp;
+                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredGroups.length / groupsPerPage) ? currentPage + 1 : Math.ceil(filteredGroups.length / groupsPerPage))}>⯈</button>
+                                </li>
+                                <li>
+                                    <input className='justMargin longInput' type="text" placeholder="Etsi ryhmiä..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
+                                </li>
+                            </ul>
+                        )}
+
+                        <div className="communityDiv">
+                            {currentGroups.map(group => (
+                                <table className="communityTbl" key={group.groupid}>
+                                    <tbody>
+                                        <tr>
+                                            <td width="250px"><b><Link to={`/group/${group.groupid}`}>{group.groupname}</Link></b></td>
+                                            <td width="250px">{user !== null && user.usertype === 'admin' && (
+                                            <AdminDeleteGroups id={group.groupid} handleDelete={handleDelete} />
+                                            )}</td>
+                                            {group.groupexplanation && (
+                                            <td>{group.groupexplanation && group.groupexplanation .length > 74 ? group.groupexplanation .substring(0, 74) + '...' : group.groupexplanation }</td>
+                                            )}
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </div>
+
+        </div>
+    );
+};
+
+export default GroupsAsList;

--- a/frontend/src/components/content/admin/ReviewsAsList.jsx
+++ b/frontend/src/components/content/admin/ReviewsAsList.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import './community.css';
-//import AdminDeleteReview from './AdminDeleteReview'; 
-import AdminDeleteReview from '@content/admin/AdminDeleteReview';
+import AdminDeleteReview from './AdminDeleteReview';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 const { VITE_APP_BACKEND_URL } = import.meta.env;
@@ -21,16 +19,9 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
   const fetchReviews = async () => {
     try {
       const newReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/reviews`);
-      //const anonReviewResponse = await axios.get(`${VITE_APP_BACKEND_URL}/reviews/anon`);
-      
       const newReviews = newReviewResponse.data;
-      //const anonReviews = anonReviewResponse.data;
-      
-      //const reviewData = [...newReviews, ...anonReviews];
-
       const reviewData = newReviews;
 
-      // Haetaan profiilitiedot
       const reviewsWithProfiles = await Promise.all(reviewData.map(async review => {
         try {
           if (review.profileid !== null) {
@@ -45,7 +36,6 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
           return review;
         }
       }));
-
 
       const reviewsWithMovies = await Promise.all(reviewsWithProfiles.map(async review => {
         try {
@@ -102,7 +92,7 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
   const currentReviews = filteredReviews.slice(indexOfFirstReview, indexOfLastReview);
 
   return (
-    <div className='allreviews'>
+    <div className='admin-reviews'>
       <ul className="review-list">
         {loading ? (
           <div className="loading-text">
@@ -110,18 +100,14 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
           </div>
         ) : (
           <>
-            <li className="userinfo">
-              Palvelussa on <b>{reviews.length}</b> arvostelua ja niiden keskiarvo 
-              on <b>{reviews.length > 0 && (reviews.reduce((sum, review) => sum + review.rating, 0) / reviews.length).toFixed(1)}</b>.<br />
-              Voit luoda uusia arvosteluja elokuvien ja sarjojen sivuilta. <br />
-            </li>
+            <h2>Arvostelujen hallinnointi</h2>
   
             <ul className="pagination">
               <li>
                 <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
                   ⯇
                 </button>
-                &nbsp; <span className="communityinfo">selaa</span> &nbsp;
+                &nbsp; <span className="admininfo">selaa</span> &nbsp;
                 <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredReviews.length / reviewsPerPage) ? currentPage + 1 : Math.ceil(filteredReviews.length / reviewsPerPage))}>
                   ⯈
                 </button>
@@ -131,7 +117,7 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
             <hr />
   
             {currentReviews.map((review, index) => (
-              <li className='minheightrews' key={index}>
+              <li className='adminrews' key={index}>
                 {review.mediatype === 0 ? (
                   <Link to={`/movie/${review.revieweditem}`}>
                     <img className='reviewimg' src={`https://image.tmdb.org/t/p/w342${review.movie.poster_path}`} alt={review.movie.title} />
@@ -143,9 +129,9 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
                 )}
   
                 {review.mediatype === 0 ? (
-                  <Link className='reviewtitle' to={`/movie/${review.revieweditem}`}>{review.movie.title}</Link>
+                  <Link className='admininfo2' to={`/movie/${review.revieweditem}`}>{review.movie.title}</Link>
                 ) : (
-                  <Link className='reviewtitle' to={`/series/${review.revieweditem}`}>{review.movie.name}</Link>
+                  <Link className='admininfo2' to={`/series/${review.revieweditem}`}>{review.movie.name}</Link>
                 )}    
   
                 <br/>
@@ -155,19 +141,19 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
                   {[...Array(5 - review.rating)].map((_, i) => (
                     <span key={i + review.rating}>&#x2605;</span>
                 ))}
-                <span className='userinfo'>| <b>{review.rating}/5</b> tähteä</span> <br />
-                <span className='reviewinfo'>
-                  <span className='reviewinfo'>{formatDate(review.timestamp)}</span> | &nbsp;
+                <span className='admininfo'>| <b>{review.rating}/5</b> tähteä</span> <br />
+                <span className='admininfo'>
+                  <span className='admininfo'>{formatDate(review.timestamp)}</span> | &nbsp;
                   {review.userProfile && review.userProfile.profilename !== undefined ? (
-                    <Link className="reviewitems" to={`/profile/${review.userProfile.profilename}`}>
+                    <Link className="admininfo" to={`/profile/${review.userProfile.profilename}`}>
                       {review.userProfile.profilename}
                     </Link>
                   ) : (
                     <i>anonyymi</i>
                   )}
                 </span><br />
-                <span className='userinfo'>{review.review}</span> <br />
-                {user.user !== null && user.user.usertype === 'admin' && (
+                <span className='admininfo'>{review.review}</span> <br />
+                {user !== null && user.usertype === 'admin' && (
                   <AdminDeleteReview id={review.idreview} handleDelete={handleDelete} />
                 )}
               </li>

--- a/frontend/src/components/content/admin/UsersAsList.jsx
+++ b/frontend/src/components/content/admin/UsersAsList.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import AdminDeleteUsers from './AdminDeleteUsers';
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
+
+const UsersAsList = ({ searchTerm, setSearchTerm, user }) => {
+    const [profiles, setProfiles] = useState([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [profilesPerPage, setProfilesPerPage] = useState(10);
+    const [loading, setLoading] = useState(true);
+    const [hoveredProfile, setHoveredProfile] = useState(null);
+    const token = sessionStorage.getItem('token');
+
+    useEffect(() => {
+        const fetchProfiles = async () => {
+            try {
+                const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile`);
+                const sortedProfiles = response.data.sort((a, b) => a.profilename.localeCompare(b.profilename));
+                setProfiles(sortedProfiles);
+                setLoading(false);
+            } catch (error) {
+                console.error('Error fetching profiles:', error);
+                setLoading(false);
+            }
+        };
+
+        fetchProfiles();
+    }, []);
+
+    const filteredProfiles = profiles.filter(profile =>
+        profile.profilename.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const indexOfLastProfile = currentPage * profilesPerPage;
+    const indexOfFirstProfile = indexOfLastProfile - profilesPerPage;
+    const currentProfiles = filteredProfiles.slice(indexOfFirstProfile, indexOfLastProfile);
+
+    const handleDelete = async (id) => {
+        setProfiles(profiles.filter(profile => profile.profileid !== id));
+     };
+
+    return (
+        <div className="admin-view">
+            <div className="admin-left">
+
+                <h2>Käyttäjien hallinnointi</h2>
+                {loading ? (
+
+                    <div className="loading-text">
+                        Ladataan käyttäjiä...
+                    </div>
+
+                ) : (
+                    <>
+                        {profiles.length > profilesPerPage && (
+                            <ul className="pagination">
+                                <li>
+                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
+                                        ⯇
+                                    </button>
+                                    &nbsp; <span className="communityBox">selaa</span> &nbsp;
+                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredProfiles.length / profilesPerPage) ? currentPage + 1 : Math.ceil(filteredProfiles.length / profilesPerPage))}>
+                                        ⯈
+                                    </button>
+                                </li>
+                                <li>
+                                    <input className='justMargin longInput'
+                                        type="text"
+                                        placeholder="Etsi käyttäjää..."
+                                        value={searchTerm}
+                                        onChange={(e) => setSearchTerm(e.target.value)}
+                                    />
+                                </li>
+                            </ul>
+                        )}
+
+
+                        <div className="communityDiv">
+                            {currentProfiles.map(profile => (
+                                <table className="communityTbl" key={profile.profileid} onMouseEnter={() => setHoveredProfile(profile)}
+                                onMouseLeave={() => setHoveredProfile(null)}> 
+                                    <tbody>
+                                        <tr>
+                                            <td width="250px"><b className='tdNames'><Link to={`/profile/${profile.profilename}`}>{profile.profilename}</Link></b></td>
+                                            <td width="250px">{user !== null && user.usertype === 'admin' && (
+                                            <AdminDeleteUsers id={profile.profileid} handleDelete={handleDelete} />
+                                            )}</td>
+                                            {profile && profile.description && (
+                                            <td>{profile.description && profile.description.length > 74 ? profile.description.substring(0, 74) + '...' : profile.description}</td>
+                                            )}
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            ))}
+                        </div>
+                    </>
+                )}
+
+            </div>
+
+
+
+
+        </div>
+    );
+};
+
+export default UsersAsList;

--- a/frontend/src/components/content/admin/admins.css
+++ b/frontend/src/components/content/admin/admins.css
@@ -1,0 +1,80 @@
+.admin-view .pagination {
+    padding-left: 30px;
+}
+
+.admin-view {
+    margin-top: 25px;
+    background-color: var(--greyblue);
+    border-top-right-radius: 40px;
+    border-top-left-radius: 40px;
+    border: 3px solid #000000;
+    color: var(--grp-text);
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap; 
+    padding: 0em;
+    box-shadow: var(--shadow02);
+}
+
+.admin-view h2 {
+    padding-left: 30px;
+    padding-top: 20px;
+}
+
+.admin-left {
+    width: 100%;
+}
+
+.buttonnext {
+    font-size: 0.8em;
+    padding: 4px;
+    box-shadow: var(--shadow02);
+}
+
+
+
+
+.adminrews {
+    min-height: 180px;
+    padding: 20px;
+    border-bottom: var(--dashedGr);
+}
+
+.adminrews:hover {
+    background-color: var(--table-tr-hover);
+}
+
+.admin-reviews {
+    background-color: var(--greyblue);
+    border-top-left-radius: 40px;
+    border-bottom-right-radius: 40px;
+    color: var(--profile);
+    display: flex-table;
+    flex-wrap: wrap;
+    padding: 1em;
+    padding-left: 2%;
+    padding-right: 2%;
+    margin-top: 25px;
+    border: 3px solid #000000;
+}
+
+.admininfo {
+    color: var(--grp-text);
+    font-size: 0.9em;
+    font-weight: 100;
+}
+
+.admininfo2 {
+    font-size: 1.4em;
+}
+
+.reviewitems {
+    color: var(--profile);
+}
+
+.reviewimg {
+    float: left;
+    margin-right: 20px;
+    height: 170px;
+    box-shadow: var(--shadow02);
+}

--- a/frontend/src/components/content/community/AdminDeleteReview.jsx
+++ b/frontend/src/components/content/community/AdminDeleteReview.jsx
@@ -24,6 +24,8 @@ const AdminDeleteReview = ({ id, handleDelete }) => {
     setShowConfirm(!showConfirm); 
   };
 
+  
+
   return (
     <div>
       {showConfirm ? ( 

--- a/frontend/src/components/content/community/AllGroups.jsx
+++ b/frontend/src/components/content/community/AllGroups.jsx
@@ -20,19 +20,10 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
     useEffect(() => {
         const fetchProfile = async () => {
             try {
-                const token = sessionStorage.getItem('token');
-                const headers = {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json'
-                };
-                console.log("Profilename from token:", user.user);
+
                 const { user: username } = user;
-                console.log("username:", username);
+
                 const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${username.user}`, { headers });
-    
-                console.log("Token from sessionStorage:", token);
-                console.log("Profilename from token:", user);
-                console.log("Response from profile:", response.data);
     
                 setProfileid(response.data.profileid);
 
@@ -49,7 +40,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
         const fetchGroups = async () => {
             try {
                 const response = await axios.get(`${VITE_APP_BACKEND_URL}/group`);
-                const sortedGroups = response.data.sort((a, b) => a.groupname.localeCompare(b.groupname));
+                const sortedGroups = response.data.sort((a, b) => a.groupname.localeCompare(b.groupname), { headers });
                 setGroups(sortedGroups);
                 setLoading(false);
             } catch (error) {

--- a/frontend/src/components/content/community/AllGroups.jsx
+++ b/frontend/src/components/content/community/AllGroups.jsx
@@ -65,7 +65,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
             const response = await axios.post(`${VITE_APP_BACKEND_URL}/group`, { groupname: newGroupName }, { headers }) ;  
             console.log('palauttaako mitään', response.data);
             const groupid = response.data[0].groupid;
-            await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/1/${groupid}/0`);
+            await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/1/${groupid}/0`, {}, { headers });
             setNewGroupName('');
             setCreatingGroup(false);
             console.log('Uusi ryhmä luotu ja jäsen lisätty onnistuneesti');

--- a/frontend/src/components/content/community/AllGroups.jsx
+++ b/frontend/src/components/content/community/AllGroups.jsx
@@ -4,6 +4,7 @@ import GroupCarousel from './GroupCarousel';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 const { VITE_APP_BACKEND_URL } = import.meta.env;
+import { getHeaders } from '@auth/token';
 
 const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
     const [groups, setGroups] = useState([]);
@@ -13,7 +14,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
     const [profileId, setProfileid] = useState(null);
     const [newGroupName, setNewGroupName] = useState('');
     const [creatingGroup, setCreatingGroup] = useState(false);
-
+    const headers = getHeaders();
 
     if (user.user !== null) {
     useEffect(() => {
@@ -27,7 +28,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
                 console.log("Profilename from token:", user.user);
                 const { user: username } = user;
                 console.log("username:", username);
-                const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${username.user}`);
+                const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${username.user}`, { headers });
     
                 console.log("Token from sessionStorage:", token);
                 console.log("Profilename from token:", user);
@@ -70,7 +71,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
 
     const handleCreateGroup = async () => {
         try {
-            const response = await axios.post(`${VITE_APP_BACKEND_URL}/group`, { groupname: newGroupName });  
+            const response = await axios.post(`${VITE_APP_BACKEND_URL}/group`, { groupname: newGroupName }, { headers }) ;  
             console.log('palauttaako mitään', response.data);
             const groupid = response.data[0].groupid;
             await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/1/${groupid}/0`);

--- a/frontend/src/components/content/group/GroupDetails.jsx
+++ b/frontend/src/components/content/group/GroupDetails.jsx
@@ -6,8 +6,9 @@ import MemberList from './MemberList';
 import ReviewList from './ReviewList';
 import Forum from './Forum';
 import GroupEdit from './GroupEdit';
-const { VITE_APP_BACKEND_URL } = import.meta.env;
 import { getHeaders } from '@auth/token';
+const { VITE_APP_BACKEND_URL } = import.meta.env;
+
 
 
 const GroupDetails = ({ user }) => {
@@ -91,9 +92,9 @@ console.log("Token from sessionStorage:", user);
   }, [id]);
 
 
-  const handleApplicationToJoin = async (profileId, groupId) => {
+  const handleApplicationToJoin = async (profileId, id) => {
     try {
-      await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/0/${groupId}/1`);
+      await axios.post(`${VITE_APP_BACKEND_URL}/memberstatus/${profileId}/0/${id}/1`, {}, {headers});
       window.location.reload(); 
     } catch (error) {
       console.error('Virhe pyynnön lähettämisessä:', error);
@@ -113,7 +114,7 @@ console.log("Token from sessionStorage:", user);
       console.log(memberResponse); 
       if (memberResponse && memberResponse.data && memberResponse.data.memberlistid) {
         try {
-          await axios.delete(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}`);
+          await axios.delete(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}`, {headers});
           window.location.reload(); 
         } catch (error) {
           console.error('Virhe pyynnön poistamisessa:', error);

--- a/frontend/src/components/content/group/GroupDetails.jsx
+++ b/frontend/src/components/content/group/GroupDetails.jsx
@@ -7,6 +7,7 @@ import ReviewList from './ReviewList';
 import Forum from './Forum';
 import GroupEdit from './GroupEdit';
 const { VITE_APP_BACKEND_URL } = import.meta.env;
+import { getHeaders } from '@auth/token';
 
 
 const GroupDetails = ({ user }) => {
@@ -15,6 +16,7 @@ const GroupDetails = ({ user }) => {
   const [editMode, setEditMode] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
   const [isMember, setIsMember] = useState(false);
+  const [isAdmin, setAdmin] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const [isMainuser, setMainuser] = useState(null);
   const [profileId, setProfileid] = useState(null);
@@ -23,26 +25,18 @@ const GroupDetails = ({ user }) => {
   const [showEvents, setShowEvents] = useState(false);
   const [showFavorites, setShowFavorites] = useState(false);
   const [loading, setLoading] = useState(true);
+  const headers = getHeaders();
 
   
   useEffect(() => { 
     const fetchProfile = async () => {
         try {
-            const token = sessionStorage.getItem('token');
-            const headers = {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            };
-
-            const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user}`);
-
-            console.log("Token from sessionStorage:", token);
-            console.log("Profilename from token:", user);
-            console.log("Response from profile:", response.data);
+           
+            const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user}`, { headers });
 
             setProfileid(response.data.profileid);
-
-            const groupResponse = await axios.get(`${VITE_APP_BACKEND_URL}/memberstatus/${response.data.profileid}/${id}`);
+            
+            const groupResponse = await axios.get(`${VITE_APP_BACKEND_URL}/memberstatus/${response.data.profileid}/${id}`, { headers });
 
             if (groupResponse.data.hasOwnProperty('pending') && groupResponse.data.pending === 0) {
               setIsMember(true);
@@ -52,7 +46,10 @@ const GroupDetails = ({ user }) => {
             }
             if (groupResponse.data.hasOwnProperty('mainuser') && groupResponse.data.mainuser === 1) {
               setMainuser(true);
-            }
+            };
+            if (user.usertype === 'admin') {
+              setAdmin(true);
+            };
 
         } catch (error) {
             console.error('Virhe haettaessa profiilitietoja:', error);
@@ -148,7 +145,8 @@ console.log("Token from sessionStorage:", user);
     setShowEvents(false);
     setShowMembers(false);
   }
-  
+
+  console.log ('usertype:', user.usertype);
 
   return (
     <div className="content"> 
@@ -168,7 +166,7 @@ console.log("Token from sessionStorage:", user);
                   alt="Käyttäjän kuva" 
                 />
 
-              {(isMainuser && !editMode) && <button onClick={() => setEditMode(true)} className="basicbutton">Muokkaa ryhmää</button>}
+              {(isAdmin || isMainuser && !editMode) && <button onClick={() => setEditMode(true)} className="basicbutton">Muokkaa ryhmää</button>}
               {(!isMember && !isPending && user && user.user !== null && user.user !== undefined) && (
               <button className="basicbutton" onClick={() => handleApplicationToJoin(profileId, id)}>Liittymispyyntö</button>
               )}
@@ -185,7 +183,7 @@ console.log("Token from sessionStorage:", user);
                 <p className="info">{group?.groupexplanation || ''} </p>
               </ul>
 
-              {isMember && (
+              {(isAdmin || isMember) && (
               <><h2>Näytä lisää</h2>
               <div className="toggleLinks">
                 <h3 onClick={toggleMembers}><span className='emoji uni07'></span>&nbsp; Jäsenlista </h3>
@@ -196,7 +194,7 @@ console.log("Token from sessionStorage:", user);
             </div>
           </div>
         
-          {isMember && (
+          {(isAdmin || isMember) && (
           <div className='group-between'>
             <div className="group-view">
               <div className='group-content'>
@@ -243,7 +241,7 @@ console.log("Token from sessionStorage:", user);
         )}
       </div>
 
-      {isMember && (
+      {(isAdmin || isMember) && (
       <div className='gmessages'>
         <h2>Keskustelu  &nbsp;<span className='emoji uni08'></span></h2>
 
@@ -254,14 +252,14 @@ console.log("Token from sessionStorage:", user);
       </div>
       )}
 
-      {isMember && (
+      {(isAdmin || isMember) && (
       <div className='greviews-view'>
         <h2>Arvostelut  &nbsp;<span className='emoji uni08'></span></h2>
         <ReviewList id={id} />
       </div>
       )}
 
-      {isMember && (
+      {(isMember) && (
       <>
         {confirmDeleteId === profileId ? (
           <>

--- a/frontend/src/components/content/group/MemberList.jsx
+++ b/frontend/src/components/content/group/MemberList.jsx
@@ -3,7 +3,7 @@ import './group.css';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 const { VITE_APP_BACKEND_URL } = import.meta.env;
-
+import { getHeaders } from '@auth/token';
 
 
 const MemberList = ({ id, user }) => {
@@ -15,25 +15,19 @@ const MemberList = ({ id, user }) => {
   const [isMainuser, setMainuser] = useState(false);
   const [memberType, setMemberType] = useState(0); 
   const [loading, setLoading] = useState(true); 
-
+  const headers = getHeaders();
+  
+  
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-          const token = sessionStorage.getItem('token');
-          const headers = {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-          };
-          
-          const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user}`);
 
-          console.log("Token from sessionStorage:", token);
-          console.log("Profilename from token:", user);
-          console.log("Response from profile:", response.data);
+          
+          const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user}`, { headers });
 
           setProfileid(response.data.profileid);
           
-          const groupResponse = await axios.get(`${VITE_APP_BACKEND_URL}/memberstatus/${response.data.profileid}/${id}`);
+          const groupResponse = await axios.get(`${VITE_APP_BACKEND_URL}/memberstatus/${response.data.profileid}/${id}`, { headers });
           
           console.log("Response from status:", groupResponse.data);
 
@@ -55,13 +49,13 @@ const MemberList = ({ id, user }) => {
       let response;
       switch (memberType) {
         case 0:
-          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/0`);
+          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/0`, { headers });
           break;
         case 1:
-          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/1`);
+          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/1`, { headers });
           break;
         case 2:
-          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/2`);
+          response = await axios.get(`${VITE_APP_BACKEND_URL}/memberlist/group/${id}/2`, { headers });
           break;
         default:
           break;
@@ -70,7 +64,7 @@ const MemberList = ({ id, user }) => {
 
         const membersWithnames = await Promise.all(memberData.map(async member => {
           try {
-            const nameResponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/id/${encodeURIComponent(member.profileid)}`);
+            const nameResponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/id/${encodeURIComponent(member.profileid)}`, { headers });
             const nameData = nameResponse.data;
             return {
               ...member,
@@ -105,7 +99,7 @@ const MemberList = ({ id, user }) => {
       console.log(memberResponse); 
       if (memberResponse && memberResponse.data && memberResponse.data.memberlistid) {
         try {
-          await axios.delete(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}`);
+          await axios.delete(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}`, { headers });
           window.location.reload(); 
         } catch (error) {
           console.error('Virhe pyynnön poistamisessa:', error);
@@ -124,8 +118,8 @@ const MemberList = ({ id, user }) => {
       console.log(memberResponse); 
       if (memberResponse && memberResponse.data && memberResponse.data.memberlistid) {
         try {
-          await axios.put(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}/0`);
-          window.location.reload(); 
+          await axios.put(`${VITE_APP_BACKEND_URL}/memberstatus/${memberResponse.data.memberlistid}/0`, {}, { headers });
+          window.location.reload();
         } catch (error) {
           console.error('Virhe pyynnön poistamisessa:', error);
         }
@@ -149,7 +143,7 @@ const MemberList = ({ id, user }) => {
       console.log("haettu memberlist:", memberResponse.data.memberlistid);  
       if (memberResponse && memberResponse.data && memberResponse.data.memberlistid) {
         try {
-          await axios.put(`${VITE_APP_BACKEND_URL}/memberrank/${memberResponse.data.memberlistid}/${rank}`);
+          await axios.put(`${VITE_APP_BACKEND_URL}/memberrank/${memberResponse.data.memberlistid}/${rank}`, {}, {headers});
           window.location.reload(); 
         } catch (error) {
           console.error('Virhe aseman muutoksessa:', error);

--- a/frontend/src/components/content/user/MyAccount.jsx
+++ b/frontend/src/components/content/user/MyAccount.jsx
@@ -153,7 +153,12 @@ export default function MyAccount({ user }) {
                 <div className="section2">
 
                     <h2>Olet kirjautunut käyttäjänä:</h2>
-                    <h1>{user.user}</h1>
+                    <h1>{user.user} </h1>
+
+                    {user && user.usertype === 'admin' && 
+                    <h2>Olet {user.usertype}: siirry {user && user.usertype === 'admin' && <Link to={`/admin`}>ylläpitoon</Link>}</h2>
+                    }
+
                     <hr />
 
                     <p>

--- a/frontend/src/components/content/user/ProfileDetails.jsx
+++ b/frontend/src/components/content/user/ProfileDetails.jsx
@@ -77,7 +77,7 @@ const ProfileDetails = ({ user }) => {
                 <div className="inner-right">
                     <h2>{profile?.profilename}</h2>
                     <ul>
-                        {(user && user.usertype === 'admin' || !isPrivate || isOwnProfile) && <p className="info">{profile?.description || ''} </p>}
+                        {(!isPrivate || isOwnProfile) && <p className="info">{profile?.description || ''} </p>}
                         {isPrivate && !isOwnProfile && <span className="userinfo">Tämä profiili on yksityinen.</span>}
                     </ul>
                 </div>
@@ -85,7 +85,7 @@ const ProfileDetails = ({ user }) => {
 
             {editMode && <ProfileEdit profilename={profilename} />}
 
-            {(user && user.usertype === 'admin' || !isPrivate || isOwnProfile) && (
+            {(!isPrivate || isOwnProfile) && (
                 <>
                     <div className='profile-between'>
 

--- a/frontend/src/components/content/user/ProfileDetails.jsx
+++ b/frontend/src/components/content/user/ProfileDetails.jsx
@@ -77,7 +77,7 @@ const ProfileDetails = ({ user }) => {
                 <div className="inner-right">
                     <h2>{profile?.profilename}</h2>
                     <ul>
-                        {(!isPrivate || isOwnProfile) && <p className="info">{profile?.description || ''} </p>}
+                        {(user && user.usertype === 'admin' || !isPrivate || isOwnProfile) && <p className="info">{profile?.description || ''} </p>}
                         {isPrivate && !isOwnProfile && <span className="userinfo">Tämä profiili on yksityinen.</span>}
                     </ul>
                 </div>
@@ -85,7 +85,7 @@ const ProfileDetails = ({ user }) => {
 
             {editMode && <ProfileEdit profilename={profilename} />}
 
-            {(!isPrivate || isOwnProfile) && (
+            {(user && user.usertype === 'admin' || !isPrivate || isOwnProfile) && (
                 <>
                     <div className='profile-between'>
 

--- a/frontend/src/components/header/Header.jsx
+++ b/frontend/src/components/header/Header.jsx
@@ -33,6 +33,7 @@ const Header = ({ user, setUser, handleLogout, toggleTheme, showLogin, setShowLo
               {user && <li>Kirjautunut:</li>} 
               {user && <li>{user.user}</li> } <br/>
 
+              {user && user.usertype === 'admin' && <li><Link to={`/admin`}>Ylläpito</Link></li>}
               {user && <li><Link to={`/profile/${user.user}`}>Oma profiili</Link></li>}
               {user && <li><Link to="/myaccount">Tilinhallinta</Link></li>}
               {user && <li><Link onClick={handleLogout}>Kirjaudu ulos</Link></li>}


### PR DESCRIPTION
**Tässä pr:ssä:**

- admin-käyttäjä näkee tilinsä sivulla tekstin "Olet admin: siirry ylläpitoon" sekä hampparivalikosta linkin ylläpito
- ylläpitosivu on rajattu muilta käyttäjiltä ja vierailta
- ylläpitosivulla admin voi poistaa arvosteluja, ryhmiä ja käyttäjiä
- admin näkee sisällön myös yksityisissä profiileissa
- admin-käyttäjiä on testidatassa kirjoitushetkellä yksi, Ninaz - ninaz
  - näitä voi tehdä lisää, vaikka testoHannulle: laputtaa kantaan usertypeen userin sijasta admin
- admin voi nähdä ryhmien sisällön vaikka ei olisi jäsenenä

Illalla lisätty mm. headersit authiin, oli authien takana olevat grouppitoiminnot rikki. Toimii nyt 👍 


