### PR TITLE
#15 : Sivupalkit leffahaussa yms

### DIFF
--- a/frontend/src/components/content/movies/Movies.jsx
+++ b/frontend/src/components/content/movies/Movies.jsx
@@ -117,11 +117,16 @@ const Movies = ({ user }) => {
     }
   };
 
+  // setGenre ja setQuery nollaus:
+  // laitoin nää siks, kun search ja discover kumoaa toisensa eli genreä ei huomioida jos on query annettu
+  // tämä hidastaa hakuja, jos pitää tyhjentää toinen osio erikseen 
   const handleInputChange = (event) => {
+    setGenre('');
     setQuery(event.target.value);
   };
 
   const handleGenreChange = (event) => {
+    setQuery(''); 
     setGenre(event.target.value);
   };
 
@@ -158,6 +163,18 @@ const Movies = ({ user }) => {
     setSeriesPage(1);
   };
   
+  const handleNullify = () => {
+    setQuery('');
+    setGenre('');
+    setYear('');
+    setMovies([]);
+    setSeries([]);
+    setShowTitles(false);
+    setMoviePage(1);
+    setSeriesPage(1);
+    setShowMovies(false);
+    setShowSeries(false);
+  }
 
   return (
     <>
@@ -242,7 +259,8 @@ const Movies = ({ user }) => {
         </div>
 
         <div>
-          <button className="basicbutton" onClick={handleSearch}>Hae</button>
+          <button className="basicbutton" onClick={handleSearch}>Hae !</button> &nbsp;
+          <button className="basicbutton" onClick={handleNullify}>Tyhjennä</button>
         </div>
 
       </div>

--- a/frontend/src/components/content/movies/Movies.jsx
+++ b/frontend/src/components/content/movies/Movies.jsx
@@ -107,7 +107,6 @@ const Movies = ({ user }) => {
     } else {
       setMoviePage((page) => Math.max(parseInt(page, 10) + 1));
     }
-    window.scrollTo(0, 600);
   };
 
   const handleSeriesPageChange = (action) => {
@@ -116,8 +115,6 @@ const Movies = ({ user }) => {
     } else {
       setSeriesPage((page) => Math.max(parseInt(page, 10) + 1));
     }
-
-    window.scrollTo(0, 600);
   };
 
   const handleInputChange = (event) => {
@@ -141,20 +138,26 @@ const Movies = ({ user }) => {
   };
 
   const toggleMovies = () => {
-    setShowMovies(!showMovies);
+    setShowMovies(true);
     setSeriesPage(1);
     setMoviePage(1);
     setShowSeries(false);
-    setShowText(false);
   };
 
   const toggleSeries = () => {
-    setShowSeries(!showSeries);
+    setShowSeries(true);
     setMoviePage(1);
     setSeriesPage(1);
     setShowMovies(false);
-    setShowText(false);
   };
+
+  const toggleAll = () => {
+    setShowMovies(true);
+    setShowSeries(true);
+    setMoviePage(1);
+    setSeriesPage(1);
+  };
+  
 
   return (
     <>
@@ -162,9 +165,7 @@ const Movies = ({ user }) => {
       <h2>Leffa- ja sarjahaku</h2>
 
       <div className="group-view-long">
-
         <div className="flex">
-
           <div className="pdd-right">
             <b>Hae nimellä</b>
             <div>
@@ -221,10 +222,23 @@ const Movies = ({ user }) => {
             />
           </div>
         </div>
-
+        
+            {showText && (
+             <div> 
+              <span className='userinfo'>Valitse tyyppi:</span>
+              {showMovies && (
+                <span className='userinfo'>elokuvat</span>
+              )}
+              {showSeries && (
+                <span className='userinfo'>sarjat</span>
+              )}
+             </div>
+            )} 
+           
         <div className='toggleLinks'>
-        <h2 onClick={toggleMovies}><span className='emoji uni01'></span> Leffat </h2>&nbsp;&nbsp;&nbsp;
-        <h2 onClick={toggleSeries}><span className='emoji justMargin'>📺</span> Sarjat </h2>
+          <h2 className='activeSearch' onClick={toggleMovies}><span className='emoji uni01'></span> Leffat </h2>&nbsp;&nbsp;&nbsp;
+          <h2 className='activeSearch' onClick={toggleSeries}><span className='emoji justMargin'>📺</span> Sarjat </h2>
+          <h2 className='activeSearch' onClick={toggleAll}><span className='emoji uni17 justMargin'></span> Kaikki </h2>&nbsp;&nbsp;&nbsp;
         </div>
 
         <div>
@@ -238,7 +252,6 @@ const Movies = ({ user }) => {
         <span className='movieinfo'>Valitse yltä haluatko nähdä leffoja vai sarjoja.</span>
       </div>
 
-    {/* Näytetään sekä elokuvat että sarjat , allekain */}
     {(showMovies && movies !== null && movies.length > 0) && (
         <div>
         <div className="resultsTitle">
@@ -256,54 +269,39 @@ const Movies = ({ user }) => {
               onChange={(event) => {
               setMoviePage(event.target.value);
               }}
-              onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                window.scrollTo(0, 600);
-                }
-              }}
+       
             />
           </div>
-        <div className="movie-container">
-        {movies.map((result) => (
-          <div key={result.id} className="movie-item">
-            <Link to={`/movie/${result.id}`}>
-              <img src={result.poster_path} alt={result.title} />
-              <div className="headoverview">
-                <div><h3>{result.title}</h3></div>
-                <div>{result.overview.length > 200 ? `${result.overview.substring(0, 200)}...` : result.overview}</div>
-              </div>
-            </Link>
-            
-              <div className='movie-mini-item'><Link to={`/movie/${result.id}`}>{result.title}</Link></div>
-            
-          </div>
-        ))}
 
+          <table class="ResultsWithButtons">
+            <tr>
+            <td class="changePageLeft" onClick={() => handleMoviePageChange('prev')}>
+                  <span class='bigArrow'>{'⯇'}</span>
+                </td>
+                <td class="betweenPages">
+                    {movies.map((result) => (
+                    <div key={result.id} class="movie-item">
+                        <Link to={`/movie/${result.id}`}>
+                            <img src={result.poster_path} alt={result.title} />
+                            <div class="headoverview">
+                                <div><h3>{result.title}</h3></div>
+                                <div>{result.overview.length > 200 ? `${result.overview.substring(0, 200)}...` : result.overview}</div>
+                            </div>
+                        </Link>
+                        <div class='movie-mini-item'><Link to={`/movie/${result.id}`}>{result.title}</Link></div>
+                    </div>
+                    ))}
+                </td>
+                <td class="changePageRight" onClick={() => handleMoviePageChange('next')}>
+                    <span class='bigArrow'>{'⯈'}</span>
+                </td>
+            </tr>
+          </table>
+          
         </div>
-        <div className="resultsTitle">
-        <button onClick={() => handleMoviePageChange('prev')} className='bigArrow'>{'⯇'}</button>
-            <h2>Elokuvat</h2>
-            <button onClick={() => handleMoviePageChange('next')} className='bigArrow'>{'⯈'}</button>      
-          </div>
-          <div className="resultsTitle">
-            <input
-              id="moviesHideable"
-              className="field shortInput"
-              type="number"
-              placeholder="..."
-              value={moviePage}
-              onChange={(event) => {
-              setMoviePage(event.target.value);
-              }}
-              onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                window.scrollTo(0, 600);
-                }
-              }}
-            />
-          </div>
-        </div>
-        )}
+      )}
+
+
         {(showSeries && series !== null && movies.length > 0) && (
         <div>
           <div className="resultsTitle">
@@ -321,53 +319,35 @@ const Movies = ({ user }) => {
               onChange={(event) => {
               setSeriesPage(event.target.value);
               }}
-              onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                window.scrollTo(0, 600);
-                }
-              }}
-            />
-          </div>
-        <div className="movie-container">  
-        {series.map((result) => (
-        <div key={result.id} className="movie-item">
-          <Link to={`/series/${result.id}`}>
-            <img src={result.poster_path} alt={result.title} />
-            <div className="headoverview">
-              <div><h3>{result.title}</h3></div>
-              <div>{result.overview.length > 200 ? `${result.overview.substring(0, 200)}...` : result.overview}</div>
-            </div>
-          </Link>
-    
-          <div className='movie-mini-item'><Link to={`/series/${result.id}`}>{result.title}</Link></div>
-            
-        </div>
-        ))}
-        </div>
-        <div className="resultsTitle">
-            <button onClick={() => handleSeriesPageChange('prev')} className='bigArrow'>{'⯇'}</button>
-            <h2>Sarjat</h2>
-            
-            <button onClick={() => handleSeriesPageChange('next')} className='bigArrow'>{'⯈'}</button>
 
-          </div>
-          <div className="resultsTitle">
-            <input
-              id="seriesHideable"
-              className="field shortInput"
-              type="number"
-              placeholder="..."
-              value={seriesPage}
-              onChange={(event) => {
-              setSeriesPage(event.target.value);
-              }}
-              onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                window.scrollTo(0, 600);
-                }
-              }}
             />
           </div>
+
+          <table class="ResultsWithButtons">
+            <tr>
+            <td class="changePageLeft" onClick={() => handleSeriesPageChange('prev')}>
+              <span class='bigArrow'>{'⯇'}</span>
+                </td>
+                <td class="betweenPages">
+                    {series.map((result) => (
+                    <div key={result.id} class="movie-item">
+                        <Link to={`/series/${result.id}`}>
+                            <img src={result.poster_path} alt={result.title} />
+                            <div class="headoverview">
+                                <div><h3>{result.title}</h3></div>
+                                <div>{result.overview.length > 200 ? `${result.overview.substring(0, 200)}...` : result.overview}</div>
+                            </div>
+                        </Link>
+                        <div class='movie-mini-item'><Link to={`/series/${result.id}`}>{result.title}</Link></div>
+                    </div>
+                    ))}
+                </td>
+                <td class="changePageRight" onClick={() => handleSeriesPageChange('next')}>
+                  <span class='bigArrow'>{'⯈'}</span>
+                </td>
+            </tr>
+          </table>
+
         </div>
       )}
       </div>

--- a/frontend/src/components/content/movies/movies.css
+++ b/frontend/src/components/content/movies/movies.css
@@ -253,6 +253,62 @@
     margin: 6px;
     box-shadow: var(--shadow05);
 }
+
+.activeSearch:active,
+.activeSearch:hover,
+.activeSearch:host {
+    color: var(--profile);
+
+}
+
+.activeSearch:checked {
+    color: var(--profile);
+
+}
+
+.changePageLeft,
+.changePageRight {
+    background-color: var(--table-bg);
+    border-left: 1px solid #000000; 
+    border-right: 1px solid #000000; 
+    box-shadow: var(--shadow05); 
+    align-items: left;
+    height: 100%;
+    font-size: 1.1em;
+    color: var(--text-color);
+    padding-left: 2px;
+    padding-right: 2px;
+    flex-grow: 1; 
+}
+
+.ResultsWithButtons td.changePageLeft:hover,
+.ResultsWithButtons td.changePageLeft:active,
+.ResultsWithButtons td.changePageRight:hover,
+.ResultsWithButtons td.changePageRight:active {
+    background-color: var(--changePage);
+}
+
+
+.changePageLeft {
+    border-bottom-left-radius: 62px;
+    border-top-left-radius: 62px;
+}
+
+.changePageRight {
+    border-bottom-right-radius: 62px;
+    border-top-right-radius: 62px;
+}
+
+.betweenPages {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+
+
 @media (max-width: 640px) {
 .movie-mini-item  {
     visibility: visible;

--- a/frontend/src/components/content/movies/movies.css
+++ b/frontend/src/components/content/movies/movies.css
@@ -258,20 +258,16 @@
 .activeSearch:hover,
 .activeSearch:host {
     color: var(--profile);
-
 }
 
 .activeSearch:checked {
     color: var(--profile);
-
 }
 
 .changePageLeft,
 .changePageRight {
     background-color: var(--table-bg);
-    border-left: 1px solid #000000; 
-    border-right: 1px solid #000000; 
-    box-shadow: var(--shadow05); 
+    box-shadow: var(--shadow02); 
     align-items: left;
     height: 100%;
     font-size: 1.1em;
@@ -280,6 +276,15 @@
     padding-right: 2px;
     flex-grow: 1; 
 }
+
+.changePageLeft {
+    border-left: 1px solid #232323; 
+}
+
+.changePageRight {
+    border-right: 1px solid #232323; 
+}
+
 
 .ResultsWithButtons td.changePageLeft:hover,
 .ResultsWithButtons td.changePageLeft:active,

--- a/frontend/src/components/content/movies/movies.css
+++ b/frontend/src/components/content/movies/movies.css
@@ -288,7 +288,6 @@
     background-color: var(--changePage);
 }
 
-
 .changePageLeft {
     border-bottom-left-radius: 62px;
     border-top-left-radius: 62px;

--- a/frontend/src/css/emoji.css
+++ b/frontend/src/css/emoji.css
@@ -65,4 +65,6 @@
 .uni15::before { content: "\1F3A5"; }
 /*noentry*/
 .uni16::before { content: "\26D4"; }
+/*wtf*/
+.uni17::before { content: "\1F5EF"; }
 

--- a/frontend/src/css/media.css
+++ b/frontend/src/css/media.css
@@ -122,6 +122,11 @@
   }
 
 
+  .changePageLeft,
+  .changePageRight {
+    font-size: 0.7em !important;
+  }
+
 }
 
 @media (max-width: 1040px) {
@@ -179,6 +184,10 @@
     min-width: 100%; /* Leveys täyteen ruutuun */
     border-left-width: 0;
     border-left: none !important;
+  }
+
+  .group-view {
+    width: 85% !important;
   }
 
 }
@@ -287,8 +296,6 @@
 }
 
 .ginner-view {    
-
-
   border-bottom-left-radius: 0px !important;
   border-bottom-right-radius: 0px !important;
 }
@@ -296,13 +303,16 @@
 .group-between {
   display: block;
   width: 100%;
-
 }
 
 .singleMember, 
 .singleEvent {
   max-width: 250px;
+}
 
+.changePageLeft,
+.changePageRight {
+  font-size: 0.5em !important;
 }
 
 }
@@ -404,11 +414,15 @@
  }
 
  .singleMember, 
-  .singleEvent {
-    padding-left: 0px !important;
+.singleEvent {
+  padding-left: 0px !important;
   max-width: 180px;
 
-}
+  }
+
+  .group-view {
+    width: 80% !important;
+  }
 
 }
 

--- a/frontend/src/css/theme.css
+++ b/frontend/src/css/theme.css
@@ -70,6 +70,7 @@
     --profile-view: #eadec8;
     --tShadow1: 0px 0px 22px #3c51f3;
     --title1: #653c14;
+    --changePage: #eadec8;
   }
 
   .dark {
@@ -113,4 +114,5 @@
     --profile-view: #cdcccb;
     --tShadow1: 0px 0px 22px #ffc746;
     --title1: #f4dec4;
+    --changePage: #2c4d81;
 }


### PR DESCRIPTION

- sivupalkit leffahaussa, jossa ne toimii selaukseen
- vaihtoehto "kaikki" -lisätty, jolla voi hakea molemmat listat (leffa ja sarja)
- tyyppien yläpuolella kerrotaan, minkä on valinnut ja se myös muistuttaa, jos käyttäjä ei ole valinnut tyyppiä (koska haku on tyhjä ilman tyyppiä)
- nullify > tyhjennysnappi kaikelle haulle
- haku tyhjenee jos käyttää discoveria (eli genreä) ja genre tyhjenee jos käyttää hakua (search), koska ne kumoaa toisensa, ja muuten kumittelu tai vetolaatikon kans puljaaminen vie aikaa
--> eri asia jos saataisiin esim searchin tilalle kokonaan pelkkä discover-toiminnallisuus mm. with_keywords -menetelmällä. 



![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/6e23ac5e-6041-4c87-8e65-84546bcb3d08)
