### PR TITLE
#97: Community sivutus haku reviews 

### DIFF
--- a/frontend/src/components/content/community/AllGroups.jsx
+++ b/frontend/src/components/content/community/AllGroups.jsx
@@ -53,9 +53,11 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
     }, []);
 
     const filteredGroups = groups.filter(group =>
-        group.groupname.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-
+        group.groupname.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (group.groupexplanation && group.groupexplanation.toLowerCase().includes(searchTerm.toLowerCase())) ||
+        (group.groupid && group.groupid.toString().toLowerCase().includes(searchTerm.toLowerCase()))
+    );    
+    
     const indexOfLastGroup = currentPage * groupsPerPage;
     const indexOfFirstGroup = indexOfLastGroup - groupsPerPage;
     const currentGroups = filteredGroups.slice(indexOfFirstGroup, indexOfLastGroup);
@@ -82,17 +84,20 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
                     <div className="loading-text">Ladataan Ryhmiä...</div>
                 ) : (
                     <>
-                        {groups.length > groupsPerPage && (
-                            <ul className="pagination">
-                                <li>
-                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>⯇</button>
-                                    &nbsp; <span className="communityBox">selaa</span> &nbsp;
-                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredGroups.length / groupsPerPage) ? currentPage + 1 : Math.ceil(filteredGroups.length / groupsPerPage))}>⯈</button>
-                                </li>
-                                <li>
-                                    <input className='justMargin longInput' type="text" placeholder="Etsi ryhmiä..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
-                                </li>
-                            </ul>
+                    {groups.length > groupsPerPage && (
+                        <ul className="pagination">
+
+                            <li>
+                                <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
+
+                                <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
+                                ⯇ </button>
+                                &nbsp; <span className="userinfo">sivu {currentPage} / {Math.ceil(filteredGroups.length / groupsPerPage)}</span> &nbsp;
+                                <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredGroups.length / groupsPerPage) ? currentPage + 1 : Math.ceil(filteredGroups.length / groupsPerPage))}>
+                                ⯈ </button>
+
+                            </li>
+                        </ul>
                         )}
 
                         <div className="communityDiv">

--- a/frontend/src/components/content/community/AllReviews.jsx
+++ b/frontend/src/components/content/community/AllReviews.jsx
@@ -17,16 +17,19 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
 
 
   useEffect(() => {
-    if (user.user !== null || user.user !== undefined) {
+    
     const fetchProfile = async () => {
+      if (user.user !== null || user.user !== undefined) {
 
       const profresponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user.user}`, { headers });
       setAdult(profresponse.data.adult);
 
+      }
+
       fetchProfile();
     };
-  }
-
+  
+  
   }, [user]);
 
   useEffect(() => {
@@ -103,7 +106,10 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
   };
 
   const filteredReviews = reviews.filter(review =>
-    review.review.toLowerCase().includes(searchTerm.toLowerCase())
+    review.review.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (review.userProfile && review.userProfile.profilename && review.userProfile.profilename.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (review.movie && review.movie.title && review.movie.title.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (review.movie && review.movie.name && review.movie.name.toLowerCase().includes(searchTerm.toLowerCase())) 
   );
 
   const indexOfLastReview = currentPage * reviewsPerPage;
@@ -124,18 +130,22 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
               on <b>{reviews.length > 0 && (reviews.reduce((sum, review) => sum + review.rating, 0) / reviews.length).toFixed(1)}</b>.<br />
               Voit luoda uusia arvosteluja elokuvien ja sarjojen sivuilta. <br />
             </li>
-  
-            <ul className="pagination">
-              <li>
-                <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
-                  ⯇
-                </button>
-                &nbsp; <span className="communityinfo">selaa</span> &nbsp;
-                <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredReviews.length / reviewsPerPage) ? currentPage + 1 : Math.ceil(filteredReviews.length / reviewsPerPage))}>
-                  ⯈
-                </button>
-              </li>
-            </ul>
+
+            {reviews.length > reviewsPerPage && (
+              <ul className="pagination">
+
+                  <li>
+                      <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
+
+                      <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
+                    ⯇ </button>
+                    &nbsp; <span className="communityinfo">sivu {currentPage} / {Math.ceil(filteredReviews.length / reviewsPerPage)}</span> &nbsp;
+                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredReviews.length / reviewsPerPage) ? currentPage + 1 : Math.ceil(filteredReviews.length / reviewsPerPage))}>
+                      ⯈ </button>
+
+                  </li>
+              </ul>
+            )}
   
             <hr />
   

--- a/frontend/src/components/content/community/UserList.jsx
+++ b/frontend/src/components/content/community/UserList.jsx
@@ -29,7 +29,8 @@ const UserList = ({ searchTerm, setSearchTerm }) => {
     }, []);
 
     const filteredProfiles = profiles.filter(profile =>
-        profile.profilename.toLowerCase().includes(searchTerm.toLowerCase())
+        profile.profilename.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (profile.profileid && profile.profileid.toString().toLowerCase().includes(searchTerm.toLowerCase()))
     );
 
     const indexOfLastProfile = currentPage * profilesPerPage;
@@ -50,27 +51,20 @@ const UserList = ({ searchTerm, setSearchTerm }) => {
                 ) : (
                     <>
                         {profiles.length > profilesPerPage && (
-                            <ul className="pagination">
-                                <li>
-                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
-                                        ⯇
-                                    </button>
-                                    &nbsp; <span className="communityBox">selaa</span> &nbsp;
-                                    <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredProfiles.length / profilesPerPage) ? currentPage + 1 : Math.ceil(filteredProfiles.length / profilesPerPage))}>
-                                        ⯈
-                                    </button>
-                                </li>
-                                <li>
-                                    <input className='justMargin longInput'
-                                        type="text"
-                                        placeholder="Etsi käyttäjää..."
-                                        value={searchTerm}
-                                        onChange={(e) => setSearchTerm(e.target.value)}
-                                    />
-                                </li>
-                            </ul>
-                        )}
+                        <ul className="pagination">
 
+                            <li>
+                                <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
+
+                                <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
+                                ⯇ </button>
+                                &nbsp; <span className="userinfo">sivu {currentPage} / {Math.ceil(filteredProfiles.length / profilesPerPage)}</span> &nbsp;
+                                <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredProfiles.length / profilesPerPage) ? currentPage + 1 : Math.ceil(filteredProfiles.length / profilesPerPage))}>
+                                ⯈ </button>
+
+                            </li>
+                        </ul>
+                        )}
 
                         <div className="communityDiv">
                             {currentProfiles.map(profile => (


### PR DESCRIPTION
Yhteisösivulla

- Arvosteluhakua parannettu:
  - haku nimisyötteellä, nimimerkillä yms. (voisi istuttaa vielä halutessa vaikka tähdet)
- Käyttäjähakua parannettu:
  - haku nimimerkillä ja id:llä (ei kuvauksella, koska osa profiileista yksityisiä)
- Ryhmähakua parannettu:
  - haku kuvauksella, ryhmän nimellä ja id:llä
- Kaikissa sivut ja ne nollaa alkuun, kun tehdään uutta hakua (ei jää sivulle X vaan siirtyy sivulle 1)

![image](https://github.com/TVTKMO23-WP-GROUP-9/Web-ohjelmoinnin-sovellusprojekti/assets/127331217/a66203dd-c5c2-4686-9a37-331dac733cb3)

- Respoa voisi parantaa snadisti, pienillä näytöillä rivittyy vielä vähän huonosti
  