### PR TITLE
#48: painikkeiden pakotusta pienemmillä näytöillä alapuolelle

### DIFF
--- a/frontend/src/components/content/admin/GroupsAsList.jsx
+++ b/frontend/src/components/content/admin/GroupsAsList.jsx
@@ -70,8 +70,7 @@ const GroupsAsList = ({ user, searchTerm, setSearchTerm }) => {
                                     <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>&#9664;</button>
                                     &nbsp; <span className="communityBox">selaa</span> &nbsp;
                                     <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredGroups.length / groupsPerPage) ? currentPage + 1 : Math.ceil(filteredGroups.length / groupsPerPage))}>&#9654;</button>
-                                </li>
-                                <li>
+                                    <span className='hideableBr'><br/></span>
                                     <input className='justMargin longInput' type="text" placeholder="Etsi ryhmiä..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
                                 </li>
                             </ul>

--- a/frontend/src/components/content/admin/UsersAsList.jsx
+++ b/frontend/src/components/content/admin/UsersAsList.jsx
@@ -64,8 +64,7 @@ const UsersAsList = ({ searchTerm, setSearchTerm, user }) => {
                                     <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(filteredProfiles.length / profilesPerPage) ? currentPage + 1 : Math.ceil(filteredProfiles.length / profilesPerPage))}>
                                         &#9654;
                                     </button>
-                                </li>
-                                <li>
+                                    <span className='hideableBr'><br/></span>
                                     <input className='justMargin longInput'
                                         type="text"
                                         placeholder="Etsi käyttäjää..."

--- a/frontend/src/components/content/community/AllGroups.jsx
+++ b/frontend/src/components/content/community/AllGroups.jsx
@@ -15,28 +15,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
     const [newGroupName, setNewGroupName] = useState('');
     const [creatingGroup, setCreatingGroup] = useState(false);
     const headers = getHeaders();
-
-    /*if (user.user !== null) {
-    useEffect(() => {
-        const fetchProfile = async () => {
-            try {
-
-                const { user: username } = user;
-
-                const response = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${username.user}`, { headers });
     
-                setProfileid(response.data.profileid);
-
-            } catch (error) {
-                console.error('Virhe haettaessa profiilitietoja:', error);
-            }
-        };
-    
-        fetchProfile();
-      }, [user]);
-    }*/
-
-
     useEffect(() => {
         const fetchGroups = async () => {
             try {
@@ -90,7 +69,7 @@ const AllGroups = ({ user, searchTerm, setSearchTerm }) => {
 
                             <li>
                                 <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
-
+                                <span className='hideableBr'><br/></span>
                                 <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
                                 &#9664; </button>
                                 &nbsp; <span className="userinfo">sivu {currentPage} / {Math.ceil(filteredGroups.length / groupsPerPage)}</span> &nbsp;

--- a/frontend/src/components/content/community/AllReviews.jsx
+++ b/frontend/src/components/content/community/AllReviews.jsx
@@ -15,7 +15,6 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
   const [adult, setAdult] = useState(false);
   const headers = getHeaders()
 
-
   useEffect(() => {
     
     const fetchProfile = async () => {
@@ -23,12 +22,10 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
 
       const profresponse = await axios.get(`${VITE_APP_BACKEND_URL}/profile/${user.user.user}`, { headers });
       setAdult(profresponse.data.adult);
-
       }
 
       fetchProfile();
     };
-  
   
   }, [user]);
 
@@ -136,7 +133,7 @@ const AllReviews = ({ searchTerm, setSearchTerm, user }) => {
 
                   <li>
                       <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
-
+                      <span className='hideableBr'><br/></span>
                       <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
                     &#9664; </button>
                     &nbsp; <span className="communityinfo">sivu {currentPage} / {Math.ceil(filteredReviews.length / reviewsPerPage)}</span> &nbsp;

--- a/frontend/src/components/content/community/UserList.jsx
+++ b/frontend/src/components/content/community/UserList.jsx
@@ -55,7 +55,7 @@ const UserList = ({ searchTerm, setSearchTerm }) => {
 
                             <li>
                                 <input className='longInput' type="text" placeholder="Etsi ..." value={searchTerm} onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }} />
-
+                                <span className='hideableBr'><br/></span>
                                 <button className="buttonnext justMargin" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
                                 &#9664; </button>
                                 &nbsp; <span className="userinfo">sivu {currentPage} / {Math.ceil(filteredProfiles.length / profilesPerPage)}</span> &nbsp;

--- a/frontend/src/components/content/group/FavoriteList.jsx
+++ b/frontend/src/components/content/group/FavoriteList.jsx
@@ -68,8 +68,8 @@ const FavoriteList = ({ id, user }) => {
       <span className="userinfo">
         Löytyi <b>{favorites.length}</b> Suosikkia.<br />
       </span>
+      <span className='hideableBr'><br/></span>
       <ul className="pagination">
-        <li>
           <button className="buttonnext" onClick={() => setCurrentPage(currentPage > 1 ? currentPage - 1 : 1)}>
             &#9664;
           </button>
@@ -77,9 +77,10 @@ const FavoriteList = ({ id, user }) => {
           <button className="buttonnext" onClick={() => setCurrentPage(currentPage < Math.ceil(favorites.length / favoritesPerPage) ? currentPage + 1 : Math.ceil(favorites.length / favoritesPerPage))}>
             &#9654;
           </button>
-          
-        </li>
+
       </ul>
+
+      <span className='hideableBr'><br/></span>
 
       {currentFavorites        
         .filter(favorite => favorite.adult === false || adult === true)

--- a/frontend/src/css/media.css
+++ b/frontend/src/css/media.css
@@ -612,6 +612,10 @@
     width: 100px !important; 
   }
 
+  .hideableBr {
+    display: inline;
+  }
+
 }
 
 /*Lopullinen breakpoint, jolloin näyttö on liian pieni, kaikkeen display none ja screenerror tms*/

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -516,3 +516,7 @@ input {
 .colored {
   color: #633912;
 }
+
+.hideableBr {
+  display: none;
+}


### PR DESCRIPTION
Joka sivulla, missä painikkeiden nuolet rivittyivät tönkösti, nyt pikkunäytöillä siirretään suoraan alapuolelle kokonaisuuksina. 
Kuitenkin admin-paneelissa edelleen jokin ylittää reunat, katsotaanko se samalla kuntoon, kun tehdään ryhmä-näytösaikojen respo?